### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = {
             // Loader for webpack to process CSS with PostCSS
             loader: 'postcss-loader',
             options: {
-              plugins: function () {
+              plugins: ()=> {
                 return [
                   require('autoprefixer')
                 ];


### PR DESCRIPTION
you should use  an arrow function in place of traditional function because you haven't defined any sort of name to that function so using traditional function will make your code bulkier and reduce its readability .